### PR TITLE
Using rejection sampling to avoid invalid salts for md5crypt (#1)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,21 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Test
+      run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jsimonetti/pwscheme
+
+go 1.13

--- a/md5crypt/md5crypt.go
+++ b/md5crypt/md5crypt.go
@@ -39,6 +39,14 @@ func Generate(password string, length uint8) (string, error) {
 		return "", err
 	}
 
+	// we need to reject salts that contain the char $
+	for strings.Count(string(salt), "$") != 0 {
+		_, err := rand.Read(salt)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	hash := fmt.Sprintf("{MD5-CRYPT}%s", crypt([]byte(password), salt))
 
 	return hash, nil

--- a/md5crypt/md5crypt_test.go
+++ b/md5crypt/md5crypt_test.go
@@ -60,12 +60,35 @@ func TestGenerate0(t *testing.T) {
 	if _, err := md5crypt.Generate("", 0); err != md5crypt.ErrSaltLengthInCorrect {
 		t.Errorf("Generated hash with too short salt did not fail")
 	}
-
 }
 
 func TestGenerate9(t *testing.T) {
 	if _, err := md5crypt.Generate("", 9); err != md5crypt.ErrSaltLengthInCorrect {
 		t.Errorf("Generated hash with too long salt did not fail")
 	}
+}
 
+func TestGenerateManyPasses(t *testing.T) {
+	pass := "foobar"
+	var hash string
+	var err error
+	var res bool
+
+	errors := 0
+
+	for i := 0; i < 1000; i++ {
+		if hash, err = md5crypt.Generate(pass, 8); err != nil {
+			t.Errorf("Generate password fails: %s", err)
+			return
+		}
+	
+		if res, err = md5crypt.Validate(pass, hash); err != nil || res != true {
+			t.Errorf("Generated hash can not be validated: %s", err)
+			errors += 1
+		}
+	}
+
+	if errors != 0 {
+		t.Errorf("%d error(s) occurred when running 1000 passes", errors)
+	}
 }

--- a/ssha/ssha_test.go
+++ b/ssha/ssha_test.go
@@ -55,3 +55,28 @@ func TestGenerate8(t *testing.T) {
 		t.Errorf("Generated hash can not be validated: %s", err)
 	}
 }
+
+func TestGenerateManyPasses(t *testing.T) {
+	pass := "foobar"
+	var hash string
+	var err error
+	var res bool
+
+	errors := 0
+
+	for i := 0; i < 1000; i++ {
+		if hash, err = ssha.Generate(pass, 8); err != nil {
+			t.Errorf("Generate password fails: %s", err)
+			return
+		}
+	
+		if res, err = ssha.Validate(pass, hash); err != nil || res != true {
+			t.Errorf("Generated hash can not be validated: %s", err)
+			errors += 1
+		}
+	}
+
+	if errors != 0 {
+		t.Errorf("%d error(s) occurred when running 1000 passes", errors)
+	}
+}

--- a/ssha256/ssha256_test.go
+++ b/ssha256/ssha256_test.go
@@ -35,7 +35,7 @@ func TestGenerate4(t *testing.T) {
 		return
 	}
 
-	if res, err = ssha256.Validate(pass, hash); err != nil && res != false {
+	if res, err = ssha256.Validate(pass, hash); err != nil || res != true {
 		t.Errorf("Generated hash can not be validated: %s", err)
 	}
 }
@@ -51,7 +51,32 @@ func TestGenerate8(t *testing.T) {
 		return
 	}
 
-	if res, err = ssha256.Validate(pass, hash); err != nil && res != false {
+	if res, err = ssha256.Validate(pass, hash); err != nil || res != true {
 		t.Errorf("Generated hash can not be validated: %s", err)
+	}
+}
+
+func TestGenerateManyPasses(t *testing.T) {
+	pass := "foobar"
+	var hash string
+	var err error
+	var res bool
+
+	errors := 0
+
+	for i := 0; i < 1000; i++ {
+		if hash, err = ssha256.Generate(pass, 8); err != nil {
+			t.Errorf("Generate password fails: %s", err)
+			return
+		}
+	
+		if res, err = ssha256.Validate(pass, hash); err != nil || res != true {
+			t.Errorf("Generated hash can not be validated: %s", err)
+			errors += 1
+		}
+	}
+
+	if errors != 0 {
+		t.Errorf("%d error(s) occurred when running 1000 passes", errors)
 	}
 }

--- a/ssha512/ssha512_test.go
+++ b/ssha512/ssha512_test.go
@@ -35,7 +35,7 @@ func TestGenerate4(t *testing.T) {
 		return
 	}
 
-	if res, err = ssha512.Validate(pass, hash); err != nil && res != false {
+	if res, err = ssha512.Validate(pass, hash); err != nil || res != true {
 		t.Errorf("Generated hash can not be validated: %s", err)
 	}
 }
@@ -51,7 +51,32 @@ func TestGenerate8(t *testing.T) {
 		return
 	}
 
-	if res, err = ssha512.Validate(pass, hash); err != nil && res != false {
+	if res, err = ssha512.Validate(pass, hash); err != nil || res != true {
 		t.Errorf("Generated hash can not be validated: %s", err)
+	}
+}
+
+func TestGenerateManyPasses(t *testing.T) {
+	pass := "foobar"
+	var hash string
+	var err error
+	var res bool
+
+	errors := 0
+
+	for i := 0; i < 1000; i++ {
+		if hash, err = ssha512.Generate(pass, 8); err != nil {
+			t.Errorf("Generate password fails: %s", err)
+			return
+		}
+	
+		if res, err = ssha512.Validate(pass, hash); err != nil || res != true {
+			t.Errorf("Generated hash can not be validated: %s", err)
+			errors += 1
+		}
+	}
+
+	if errors != 0 {
+		t.Errorf("%d error(s) occurred when running 1000 passes", errors)
 	}
 }


### PR DESCRIPTION
This fixes #1 

* Using rejection sampling to avoid invalid salts for md5crypt
* Adding many passes tests to all schemes and patching the existing tests
* Adding CI tests
* Adding go mod